### PR TITLE
[FIX; Android] Looky-8019: unable to instantiate FragmentModalBottomSheet

### DIFF
--- a/android/src/main/java/com/sheet/FragmentModalBottomSheet.kt
+++ b/android/src/main/java/com/sheet/FragmentModalBottomSheet.kt
@@ -5,6 +5,7 @@ import android.content.DialogInterface
 import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -14,12 +15,20 @@ import androidx.core.view.WindowInsetsControllerCompat
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import java.lang.ref.WeakReference
 
+// Empty Constructor is required for Fragment Recreation,
+// see https://oneclicklife.youtrack.cloud/issue/Looky-8019/Krash-iz-metriki-NoSuchMethodException-at-RNScreensFragmentFactory
 class FragmentModalBottomSheet(
-  private val modalView: ViewGroup,
-  private val dismissable: Boolean,
+  private val modalView: ViewGroup? = null,
+  private val dismissable: Boolean = true,
   private val isContentBackgroundLight: Boolean = true,
-  private val onDismiss: (dismissAll: Boolean) -> Unit
+  private val onDismiss: (dismissAll: Boolean) -> Unit = {},
 ) : BottomSheetDialogFragment() {
+  init {
+    Log.d(
+      "com.sheet",
+      "FragmentModalBottomSheet.Init | isModalViewDefined: ${modalView != null}, dismissable: $dismissable, isContentBackgroundLight: $isContentBackgroundLight, onDismiss: $onDismiss"
+    )
+  }
 
   var dismissAll = false
 
@@ -31,7 +40,7 @@ class FragmentModalBottomSheet(
     inflater: LayoutInflater,
     container: ViewGroup?,
     savedInstanceState: Bundle?
-  ): View = modalView
+  ): View? = modalView
 
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
     this.isCancelable = dismissable

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sheet",
-  "version": "6.3.0",
+  "version": "6.3.2",
   "description": "Native implementation of Bottom sheet",
   "main": "src/index.tsx",
   "module": "src/index",


### PR DESCRIPTION
# Merge with https://github.com/oneclick-llc/rn-looky/pull/727

[Looky-8019](https://oneclicklife.youtrack.cloud/issue/Looky-8019) Краш из метрики NoSuchMethodException at RNScreensFragmentFactory